### PR TITLE
Chaosmachine annotation processor

### DIFF
--- a/chaosmachine/README.md
+++ b/chaosmachine/README.md
@@ -13,6 +13,79 @@ More details in the Arxiv paper: [A Chaos Engineering System for Live Analysis a
 - [Stockholm Chaos Engineering Meetup, Stockholm, Sweden, Tuesday, June 19, 2018](https://www.meetup.com/Stockholm-Chaos-Engineering-Community/events/250982413/)
 - [2nd European Chaos Engineering Day, Stockholm, Sweden, Wednesday, December 05, 2018](https://www.chaos.conf.kth.se/)
 
+## The Usage of ChaosMachineAnnotationProcessor
+
+With the help of [Spoon](http://spoon.gforge.inria.fr/), ChaosMachine provides an AnnotationProcessor. If sourcecode is avaliable, developers could use annotations to mark try-catch blocks for their convenience. Then the processor will generate a configuration file for ChaosMachine's experiments.
+
+First of all, you need to package the annotation processor by running:
+
+```
+cd annotation_processor && mvn package
+```
+
+In the `target` folder you will get `chaosmachine-annotation-processor.jar`, which developers need to import into their project in order to use the annotation `ChaosMachinePerturbationPoint`. It will be even more convenient after the ChaosMachine components are registered to Maven Central Repository.
+
+Currently, developers need to add the following part into `pom.xml`.
+
+```
+<plugins>
+	<plugin>
+		<groupId>fr.inria.gforge.spoon</groupId>
+		<artifactId>spoon-maven-plugin</artifactId>
+		<version>3.1</version>
+		<executions>
+			<execution>
+				<phase>generate-sources</phase>
+				<goals>
+					<goal>generate</goal>
+				</goals>
+			</execution>
+		</executions>
+		<configuration>
+			<processors>
+				<processor>
+					se.kth.chaos.ChaosMachineAnnotationProcessor
+				</processor>
+			</processors>
+			<!-- setup of configurationFilePath is not mandatory, the default value is ./chaosmachine_config.csv -->
+			<processorProperties>
+				<processorProperty>
+					<name>se.kth.chaos.ChaosMachineAnnotationProcessor</name>
+				<properties>
+					<property>
+						<name>configurationFilePath</name>
+						<value>./perturbationPoints.csv</value>
+					</property>
+				</properties>
+				</processorProperty>
+				</processorProperties>
+			<skipGeneratedSources>true</skipGeneratedSources>
+		</configuration>
+		<dependencies>
+			<dependency>
+				<groupId>fr.inria.gforge.spoon</groupId>
+				<artifactId>spoon-core</artifactId>
+				<version>7.4.0-beta-12</version>
+			</dependency>
+		</dependencies>
+	</plugin>
+</plugins>
+```
+
+Now enjoy, developers could use the annotation like this:
+
+```
+try {
+    ...
+} catch (@ChaosMachinePerturbationPoint(hypothesis = Hypothesis.RESILIENT) MissingPropertyException e) {
+    ...
+} catch (@ChaosMachinePerturbationPoint(hypothesis = {Hypothesis.DEBUG, Hypothesis.OBSERVABLE}) Exception e) {
+    ...
+}
+```
+
+And when the project is compiled, a configuration file for ChaosMachine is automatically generated.
+
 ## How to conduct a chaos experiment using Chaos Machine
 
 Run the following command in root directory:

--- a/chaosmachine/annotation_processor/pom.xml
+++ b/chaosmachine/annotation_processor/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Chaos Machine - Annotation Processor</name>
+  <groupId>se.kth.chaos</groupId>
+  <artifactId>chaosmachine-annotation-processor</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>fr.inria.gforge.spoon</groupId>
+      <artifactId>spoon-core</artifactId>
+      <version>7.4.0-beta-12</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/chaosmachine/annotation_processor/src/main/java/se/kth/chaos/ChaosMachineAnnotationProcessor.java
+++ b/chaosmachine/annotation_processor/src/main/java/se/kth/chaos/ChaosMachineAnnotationProcessor.java
@@ -1,0 +1,78 @@
+package se.kth.chaos;
+
+import org.apache.log4j.Level;
+import se.kth.chaos.annotations.ChaosMachinePerturbationPoint;
+import spoon.processing.AbstractAnnotationProcessor;
+import spoon.processing.Property;
+import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtTry;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChaosMachineAnnotationProcessor extends AbstractAnnotationProcessor<ChaosMachinePerturbationPoint, CtCatch> {
+    @Property
+    String configurationFilePath = "./chaosmachine_config.csv";
+
+    public void process(ChaosMachinePerturbationPoint chaosMachinePerturbationPoint, CtCatch ctCatch) {
+        CtTry ctTry = (CtTry)ctCatch.getParent();
+        CtClass ctClass = ctCatch.getParent(CtClass.class);
+        CtMethod ctMethod = ctCatch.getParent(CtMethod.class);
+
+        String className = ctClass.getQualifiedName();
+        String methodName = ctMethod.getSimpleName();
+        String methodSignature = ctMethod.getSignature();
+        String exceptionType = ctCatch.getParameter().getType().toString();
+        int lineIndexNumber = ctTry.getPosition().getLine();
+        List<String> hypotheses = new ArrayList<String>();
+        for (int i = 0; i < chaosMachinePerturbationPoint.hypothesis().length; i++) {
+            hypotheses.add(chaosMachinePerturbationPoint.hypothesis()[i].name());
+        }
+
+        this.registerPerturbationPoint(className, methodName, methodSignature, exceptionType, String.valueOf(lineIndexNumber), String.join("|", hypotheses));
+
+        getFactory().getEnvironment().report(this, Level.INFO, ctTry, "ChaosMachinePerturbationPoint detected, exception type: " + exceptionType);
+    }
+
+    private void registerPerturbationPoint(String className, String methodName, String methodSignature,
+                                          String exceptionType, String lineIndexNumber, String hypothesis) {
+        // register to a csv file
+        File csvFile = new File(this.configurationFilePath);
+        try {
+            MessageDigest mDigest = MessageDigest.getInstance("MD5");
+            String key = byteArrayToHex(mDigest.digest((className + methodName + lineIndexNumber).getBytes()));
+
+            PrintWriter out = null;
+            if (csvFile.exists()) {
+                out = new PrintWriter(new FileWriter(csvFile, true));
+                out.println(String.format("%s,%s,%s,%s,%s,%s,%s", key, className, methodName, methodSignature, exceptionType, lineIndexNumber, hypothesis));
+            } else {
+                csvFile.createNewFile();
+                out = new PrintWriter(new FileWriter(csvFile));
+                out.println("key,className,methodName,methodSignature,exceptionType,lineIndexNumber,hypothesis");
+                out.println(String.format("%s,%s,%s,%s,%s,%s,%s", key, className, methodName, methodSignature, exceptionType, lineIndexNumber, hypothesis));
+            }
+            out.flush();
+            out.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String byteArrayToHex(byte[] byteArray) {
+        char[] hexDigits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+        char[] resultCharArray = new char[byteArray.length * 2];
+        int index = 0;
+        for (byte b : byteArray) {
+            resultCharArray[index++] = hexDigits[b >>> 4 & 0xf];
+            resultCharArray[index++] = hexDigits[b & 0xf];
+        }
+        return new String(resultCharArray);
+    }
+}

--- a/chaosmachine/annotation_processor/src/main/java/se/kth/chaos/annotations/ChaosMachinePerturbationPoint.java
+++ b/chaosmachine/annotation_processor/src/main/java/se/kth/chaos/annotations/ChaosMachinePerturbationPoint.java
@@ -1,0 +1,12 @@
+package se.kth.chaos.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ChaosMachinePerturbationPoint {
+    Hypothesis[] hypothesis();
+}

--- a/chaosmachine/annotation_processor/src/main/java/se/kth/chaos/annotations/Hypothesis.java
+++ b/chaosmachine/annotation_processor/src/main/java/se/kth/chaos/annotations/Hypothesis.java
@@ -1,0 +1,8 @@
+package se.kth.chaos.annotations;
+
+public enum Hypothesis {
+    RESILIENT,
+    OBSERVABLE,
+    DEBUG,
+    SILENT
+}

--- a/chaosmachine/annotation_processor/src/test/java/se/kth/chaos/AnnotationsBasicTest.java
+++ b/chaosmachine/annotation_processor/src/test/java/se/kth/chaos/AnnotationsBasicTest.java
@@ -1,0 +1,4 @@
+package se.kth.chaos;
+
+public class AnnotationsBasicTest {
+}

--- a/chaosmachine/annotation_processor/src/test/java/se/kth/chaos/testfiles/MissingPropertyException.java
+++ b/chaosmachine/annotation_processor/src/test/java/se/kth/chaos/testfiles/MissingPropertyException.java
@@ -1,0 +1,4 @@
+package se.kth.chaos.testfiles;
+
+public class MissingPropertyException extends Exception {
+}

--- a/chaosmachine/annotation_processor/src/test/java/se/kth/chaos/testfiles/TryCatchTestObject.java
+++ b/chaosmachine/annotation_processor/src/test/java/se/kth/chaos/testfiles/TryCatchTestObject.java
@@ -1,0 +1,20 @@
+package se.kth.chaos.testfiles;
+
+import se.kth.chaos.annotations.ChaosMachinePerturbationPoint;
+import se.kth.chaos.annotations.Hypothesis;
+
+public class TryCatchTestObject {
+    public void tryCatchWithAnnotations() {
+        try {
+            String arg = getArgument();
+        } catch (@ChaosMachinePerturbationPoint(hypothesis = Hypothesis.RESILIENT) MissingPropertyException e) {
+            e.printStackTrace();
+        } catch (@ChaosMachinePerturbationPoint(hypothesis = {Hypothesis.DEBUG, Hypothesis.OBSERVABLE}) Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String getArgument() throws MissingPropertyException {
+        return null;
+    }
+}

--- a/tripleagent/agents_controller/hedwig_evaluation_0.7/restart_hedwig.sh
+++ b/tripleagent/agents_controller/hedwig_evaluation_0.7/restart_hedwig.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# the hedwig server root path
+hedwig_root_path="/home/ubuntu/development/hedwig-0.7/hedwig-0.7-bin"
+
+rm -rf $hedwig_root_path/spool
+rm $hedwig_root_path/bin/*.csv
+cd $hedwig_root_path/bin
+./run.sh restart
+


### PR DESCRIPTION
With the help of Spoon, ChaosMachine has a AnnotationProcessor now. If sourcecode is avaliable, developers could use annotations to mark try-catch blocks. Then the processor will generate a configuration file for ChaosMachine.